### PR TITLE
Node module name seems to have changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ A) Include the module in your code
 
 ```typescript
 // Typescript
-import { AhoiApiFactory } from 'ahoi-api-node';
+import { AhoiApiFactory } from 'ahoi-nodejs-client';
 
 // JavaScript
-const { AhoiApiFactory } = require('ahoi-api-node');
+const { AhoiApiFactory } = require('ahoi-nodejs-client');
 ```
 
 B) Add the configuration to access the AHOI API


### PR DESCRIPTION
Change seems to be now 'ahoi-nodejs-client'. You b.t.w. need to have portable-fetch installed, to.
Furthermore I found npm run build not working:
"error TS5014: Failed to parse file '/Users/karsten/tmp/RH/ahoi-nodejs-client/tsconfig.json': Unexpected token } in JSON at position 508."